### PR TITLE
feat: 支持后台手动上传停车场二维码

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@
 - 停车券创建
   - 录入总次数，生成券号与二维码
   - 返回可直接访问的使用页链接
+- 手动上传停车场二维码
+  - 管理员可在后台为停车券上传二维码图片
+  - 使用页展码优先展示手动上传二维码（未上传时回退自动二维码）
 - 停车券使用（展码 + 确认扣减）
   - 展示券二维码
   - 每次确认使用扣减 1 次
@@ -121,19 +124,23 @@ PORT=9090 DATA_DIR=/tmp/parking-coupon-data node server.js
 ### 7.2 管理员发券与历史
 
 - `POST /api/admin/voucher`
-  - body: `{ "total": 50 }`
-  - 返回：`voucher`, `redeemUrl`, `redeemFullUrl`, `qrDataUrl`
+  - body: `{ "total": 50, "manualQrDataUrl": "data:image/png;base64,..." }`
+  - `manualQrDataUrl` 可选，支持 `PNG/JPEG/WEBP`
+  - 返回：`voucher`, `redeemUrl`, `redeemFullUrl`, `qrDataUrl`, `voucherQrSource`
+- `POST /api/admin/voucher/:id/manual-qr`
+  - body: `{ "qrDataUrl": "data:image/png;base64,..." }`
+  - 为指定停车券上传/更新手动二维码
 - `GET /api/admin/vouchers?page=1&pageSize=10&q=关键词`
   - 返回：
-    - `items[]`：每张券 `id/total/used/remain/status/createdAt/warning`
+    - `items[]`：每张券 `id/total/used/remain/status/createdAt/qrSource/manualQrUploadedAt/warning`
     - `pagination`：分页信息
     - `summary`：汇总统计
 
 ### 7.3 停车券使用 API（登录后）
 
-- `GET /api/voucher/:id`：查询券详情
+- `GET /api/voucher/:id`：查询券详情（返回 `qrDataUrl` 与 `qrSource`）
 - `POST /api/voucher/:id/display`：记录展码行为
-- `POST /api/voucher/:id/confirm`：确认使用并扣减
+- `POST /api/voucher/:id/confirm`：确认使用并扣减（返回 `qrDataUrl` 与 `qrSource`）
 
 ## 8. 数据存储说明
 
@@ -148,7 +155,12 @@ PORT=9090 DATA_DIR=/tmp/parking-coupon-data node server.js
     "total": 50,
     "remain": 49,
     "createdAt": "2026-02-10T12:00:00.000Z",
-    "status": "active"
+    "status": "active",
+    "manualQr": {
+      "dataUrl": "data:image/png;base64,...",
+      "uploadedAt": "2026-02-11T08:30:00.000Z",
+      "uploadedBy": "qzadmin"
+    }
   }
 }
 ```

--- a/public/admin.html
+++ b/public/admin.html
@@ -10,7 +10,7 @@
   <main class="page">
     <section class="hero">
       <h1 class="title">管理员后台</h1>
-      <p class="subtitle">登录后创建停车券二维码。固定账号：<b>qzadmin</b>。</p>
+      <p class="subtitle">登录后创建停车券并支持手动上传停车场二维码。固定账号：<b>qzadmin</b>。</p>
     </section>
 
     <section class="grid grid-2">
@@ -67,14 +67,17 @@
         <div class="kv-item"><span class="muted">券号</span><b id="voucherId" class="mono">-</b></div>
         <div class="kv-item"><span class="muted">剩余次数</span><b id="voucherRemain">-</b></div>
         <div class="kv-item"><span class="muted">使用链接</span><a id="redeemLink" class="mono" href="#" target="_blank" rel="noopener">-</a></div>
+        <div class="kv-item"><span class="muted">展码来源</span><b id="voucherQrSource">自动生成</b></div>
       </div>
       <div class="actions" style="margin-top:12px">
         <button class="btn btn-secondary" id="copyLinkBtn" type="button">复制链接</button>
+        <button class="btn btn-secondary" id="uploadQrBtn" type="button">上传二维码</button>
       </div>
+      <input id="qrUploadInput" type="file" accept="image/png,image/jpeg,image/webp" style="display:none"/>
       <div class="qr-wrap">
         <img id="qr" alt="voucher qrcode"/>
       </div>
-      <p class="muted" style="margin:0">建议车主或收费员使用手机扫码打开使用页。</p>
+      <p class="muted" style="margin:0">默认展示的是使用页二维码；上传后“使用页展码”会优先使用手动上传二维码。</p>
     </section>
 
     <section class="card" id="historyCard" style="display:none; margin-top:14px">
@@ -111,6 +114,8 @@
               <th>已用</th>
               <th>剩余</th>
               <th>状态</th>
+              <th>二维码来源</th>
+              <th>操作</th>
             </tr>
           </thead>
           <tbody id="historyTableBody"></tbody>
@@ -150,6 +155,10 @@ const historyTableBody = document.getElementById('historyTableBody');
 const historyPrevBtn = document.getElementById('historyPrevBtn');
 const historyNextBtn = document.getElementById('historyNextBtn');
 const historyPageInfo = document.getElementById('historyPageInfo');
+const qrUploadInput = document.getElementById('qrUploadInput');
+const uploadQrBtn = document.getElementById('uploadQrBtn');
+
+let latestVoucherId = '';
 
 const historyState = {
   page: 1,
@@ -187,6 +196,11 @@ function warningBadge(level) {
   return { cls: 'badge badge-ok', text: '正常' };
 }
 
+function qrSourceBadge(source) {
+  if (source === 'manual') return { cls: 'badge badge-teal', text: '手动上传' };
+  return { cls: 'badge badge-light', text: '自动生成' };
+}
+
 function showBanner(el, type, text) {
   el.className = 'banner ' + (type === 'error' ? 'banner-error' : 'banner-success');
   el.textContent = text;
@@ -210,6 +224,7 @@ function setLoggedOut() {
   whoami.textContent = '';
   historyTableBody.innerHTML = '';
   historyPageInfo.textContent = '第 1 / 1 页';
+  latestVoucherId = '';
   showBanner(historyBanner, 'error', '');
 }
 
@@ -224,10 +239,12 @@ function renderHistory(data) {
   document.getElementById('sumRemain').textContent = String(summary.totalRemain || 0);
 
   if (!items.length) {
-    historyTableBody.innerHTML = '<tr><td colspan="6" class="muted">没有匹配的停车券记录</td></tr>';
+    historyTableBody.innerHTML = '<tr><td colspan="8" class="muted">没有匹配的停车券记录</td></tr>';
   } else {
     historyTableBody.innerHTML = items.map((item) => {
       const badge = warningBadge(item.warning?.level || 'ok');
+      const qrBadge = qrSourceBadge(item.qrSource);
+      const qrActionLabel = item.qrSource === 'manual' ? '更新二维码' : '上传二维码';
       return `<tr>
         <td class="mono">${escapeHtml(item.id || '-')}</td>
         <td>${escapeHtml(toDisplayTime(item.createdAt))}</td>
@@ -235,6 +252,8 @@ function renderHistory(data) {
         <td>${item.used}</td>
         <td>${item.remain}</td>
         <td><span class="${badge.cls}">${badge.text}</span></td>
+        <td><span class="${qrBadge.cls}">${qrBadge.text}</span></td>
+        <td><button class="btn btn-secondary btn-xs" type="button" data-upload-voucher="${escapeHtml(item.id || '')}">${qrActionLabel}</button></td>
       </tr>`;
     }).join('');
   }
@@ -351,11 +370,16 @@ async function createVoucher() {
     resultCard.style.display = 'block';
     document.getElementById('voucherId').textContent = d.voucher.id;
     document.getElementById('voucherRemain').textContent = String(d.voucher.remain);
+    latestVoucherId = d.voucher.id;
 
     const linkEl = document.getElementById('redeemLink');
     linkEl.href = d.redeemFullUrl;
     linkEl.textContent = d.redeemFullUrl;
 
+    const sourceBadge = qrSourceBadge(d.voucherQrSource);
+    const sourceEl = document.getElementById('voucherQrSource');
+    sourceEl.textContent = sourceBadge.text;
+    sourceEl.className = sourceBadge.cls;
     document.getElementById('qr').src = d.qrDataUrl;
     await loadHistory({ resetPage: true });
     showBanner(workBanner, 'success', '停车券创建成功。');
@@ -377,6 +401,70 @@ async function copyLink() {
   }
 }
 
+function fileToDataUrl(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(new Error('读取图片失败'));
+    reader.onload = () => resolve(String(reader.result || ''));
+    reader.readAsDataURL(file);
+  });
+}
+
+async function uploadManualQrForVoucher(voucherId, file) {
+  if (!voucherId) {
+    showBanner(workBanner, 'error', '请先创建或选择一个停车券。');
+    return;
+  }
+  if (!file) return;
+  if (!file.type.startsWith('image/')) {
+    showBanner(workBanner, 'error', '仅支持上传图片文件。');
+    return;
+  }
+
+  uploadQrBtn.disabled = true;
+  showBanner(workBanner, 'error', '');
+  try {
+    const qrDataUrl = await fileToDataUrl(file);
+    const r = await fetch('/api/admin/voucher/' + encodeURIComponent(voucherId) + '/manual-qr', {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ qrDataUrl })
+    });
+    const d = await r.json();
+    if (!r.ok) {
+      if (r.status === 401) {
+        setLoggedOut();
+        showBanner(loginBanner, 'error', '登录已失效，请重新登录。');
+        return;
+      }
+      showBanner(workBanner, 'error', d.message || d.error || '上传失败');
+      return;
+    }
+
+    latestVoucherId = voucherId;
+    document.getElementById('voucherId').textContent = voucherId;
+    document.getElementById('voucherRemain').textContent = String(d.voucher?.remain ?? '-');
+    const redeemFullUrl = location.origin + '/redeem.html?v=' + encodeURIComponent(voucherId);
+    const linkEl = document.getElementById('redeemLink');
+    linkEl.href = redeemFullUrl;
+    linkEl.textContent = redeemFullUrl;
+    const sourceBadge = qrSourceBadge('manual');
+    const sourceEl = document.getElementById('voucherQrSource');
+    sourceEl.textContent = sourceBadge.text;
+    sourceEl.className = sourceBadge.cls;
+    document.getElementById('qr').src = d.qrDataUrl || '';
+    resultCard.style.display = 'block';
+    await loadHistory();
+    showBanner(workBanner, 'success', '二维码上传成功，使用页将优先展示手动二维码。');
+  } catch {
+    showBanner(workBanner, 'error', '网络错误，二维码上传失败。');
+  } finally {
+    uploadQrBtn.disabled = false;
+    qrUploadInput.value = '';
+  }
+}
+
 document.getElementById('loginForm').addEventListener('submit', (e) => {
   e.preventDefault();
   login();
@@ -391,6 +479,14 @@ document.querySelectorAll('[data-total]').forEach((btn) => {
 document.getElementById('createBtn').addEventListener('click', createVoucher);
 document.getElementById('logoutBtn').addEventListener('click', logout);
 document.getElementById('copyLinkBtn').addEventListener('click', copyLink);
+document.getElementById('uploadQrBtn').addEventListener('click', () => {
+  if (!latestVoucherId) {
+    showBanner(workBanner, 'error', '请先生成停车券，再上传二维码。');
+    return;
+  }
+  qrUploadInput.dataset.targetVoucher = latestVoucherId;
+  qrUploadInput.click();
+});
 document.getElementById('refreshHistoryBtn').addEventListener('click', () => loadHistory());
 document.getElementById('historySearchBtn').addEventListener('click', () => {
   historyState.q = historySearchInput.value.trim();
@@ -413,6 +509,19 @@ historyPrevBtn.addEventListener('click', () => {
 historyNextBtn.addEventListener('click', () => {
   historyState.page = Math.min(historyState.totalPages, historyState.page + 1);
   loadHistory();
+});
+qrUploadInput.addEventListener('change', () => {
+  const targetVoucher = qrUploadInput.dataset.targetVoucher || latestVoucherId;
+  const file = qrUploadInput.files && qrUploadInput.files[0];
+  uploadManualQrForVoucher(targetVoucher, file);
+});
+historyTableBody.addEventListener('click', (event) => {
+  const button = event.target instanceof HTMLElement ? event.target.closest('[data-upload-voucher]') : null;
+  if (!button) return;
+  const voucherId = button.getAttribute('data-upload-voucher') || '';
+  latestVoucherId = voucherId;
+  qrUploadInput.dataset.targetVoucher = voucherId;
+  qrUploadInput.click();
 });
 
 checkSession();

--- a/public/styles.css
+++ b/public/styles.css
@@ -127,6 +127,11 @@ input:focus {
   cursor: not-allowed;
 }
 
+.btn-xs {
+  padding: 6px 10px;
+  font-size: 12px;
+}
+
 .badge {
   display: inline-flex;
   align-items: center;
@@ -150,6 +155,16 @@ input:focus {
 .badge-danger {
   color: #991b1b;
   background: #fee2e2;
+}
+
+.badge-light {
+  color: #334155;
+  background: #e2e8f0;
+}
+
+.badge-teal {
+  color: #0f766e;
+  background: #ccfbf1;
 }
 
 .banner {
@@ -316,7 +331,7 @@ input:focus {
 
 .history-table {
   width: 100%;
-  min-width: 700px;
+  min-width: 860px;
   border-collapse: collapse;
   font-size: 14px;
 }


### PR DESCRIPTION
## 关联 Issue
Closes #1

## 变更内容
- 新增后台接口 `POST /api/admin/voucher/:id/manual-qr`，支持管理员上传/更新二维码图片（Data URL）
- 停车券详情与核销返回值新增 `qrSource`，并在有手动二维码时优先返回手动二维码
- 后台页面新增上传入口（生成结果区 + 历史列表操作），支持上传后即时生效
- 历史列表新增二维码来源字段（自动生成/手动上传）
- 增加上传数据校验（图片类型、Data URL 格式、大小限制）
- 扩展回归测试覆盖手动上传流程与权限校验
- 更新 README 文档（功能说明、API、数据结构）

## 验证
- `npm test`
